### PR TITLE
Claim node-selector for the namespace

### DIFF
--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
     name: openshift-cluster-node-tuning-operator
+    annotations:
+        openshift.io/node-selector: ""


### PR DESCRIPTION
Otherwise, tuned pods would not run on master/infra nodes if `defaultNodeSelector: node-role.kubernetes.io/compute=true` in `/etc/origin/master/master-config.yaml`.